### PR TITLE
AutoPlay优化：增加键盘控制和随机Fast/Late

### DIFF
--- a/Cheat/AutoPlay.cs
+++ b/Cheat/AutoPlay.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using MAI2.Util;
 using Manager;
 using Monitor;
@@ -89,14 +89,21 @@ namespace SinmaiAssist.Cheat
                 case AutoPlayMode.Critical:
                     __result = NoteJudge.ETiming.Critical;
                     break;
+                // 随机Fast或Late
                 case AutoPlayMode.Perfect:
-                    __result = NoteJudge.ETiming.LatePerfect2nd;
+                    __result = UnityEngine.Random.Range(0, 2) == 0 
+                        ? NoteJudge.ETiming.LatePerfect2nd 
+                        : NoteJudge.ETiming.FastPerfect2nd;
                     break;
                 case AutoPlayMode.Great:
-                    __result = NoteJudge.ETiming.LateGreat;
+                    __result = UnityEngine.Random.Range(0, 2) == 0 
+                        ? NoteJudge.ETiming.LateGreat 
+                        : NoteJudge.ETiming.FastGreat;
                     break;
                 case AutoPlayMode.Good:
-                    __result = NoteJudge.ETiming.LateGood;
+                    __result = UnityEngine.Random.Range(0, 2) == 0 
+                        ? NoteJudge.ETiming.LateGood 
+                        : NoteJudge.ETiming.FastGood;
                     break;
                 case AutoPlayMode.Random:
                     __result = RandomJudgeTiming[UnityEngine.Random.Range(0, RandomJudgeTiming.Count)];

--- a/GUI/AutoPlayPanel.cs
+++ b/GUI/AutoPlayPanel.cs
@@ -11,12 +11,27 @@ public class AutoPlayPanel
         AutoPlay.DisableUpdate = GUILayout.Toggle(AutoPlay.DisableUpdate, "Disable Mode Update");
         if (GUILayout.Button("Critical (AP+)", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Critical;
         if (GUILayout.Button("Perfect", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Perfect;
-        if (GUILayout.Button("Great", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Great;
-        if (GUILayout.Button("Good", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Good;
-        if (GUILayout.Button("Random", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Random;
-        if (GUILayout.Button("RandomAllPerfect", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomAllPerfect;
-        if (GUILayout.Button("RandomFullComboPlus", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomFullComboPlus;
-        if (GUILayout.Button("RandomFullCombo", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomFullCombo;
-        if (GUILayout.Button("None", MainGUI.Style.Button)) AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.None;
+
+        // 键盘控制部分AutoPlay模式，全大P/全小P没有意义所以不考虑增加
+        if (GUILayout.Button("Great", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.O))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Great;
+
+        if (GUILayout.Button("Good", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.P))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Good;
+
+        if (GUILayout.Button("Random", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.K))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.Random;
+
+        if (GUILayout.Button("RandomAllPerfect", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.G))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomAllPerfect;
+
+        if (GUILayout.Button("RandomFullComboPlus", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.H))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomFullComboPlus;
+
+        if (GUILayout.Button("RandomFullCombo", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.J))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.RandomFullCombo;
+
+        if (GUILayout.Button("None", MainGUI.Style.Button) || DebugInput.GetKeyDown(KeyCode.N))
+            AutoPlay.autoPlayMode = AutoPlay.AutoPlayMode.None;
     }
 }


### PR DESCRIPTION
## 改进点
- 增加部分AutoPlay模式的键盘快捷键：G键AP，H键FC+，J键FC，K键随机，O键全粉，P键全绿。考虑到全大P和全小P的意义不大，这两个模式没有增加对应的键盘快捷键。
- 将全小P、全粉、全绿由“仅Late”改为“随机Fast/Late”。